### PR TITLE
BUG: Fix shebangs in bash scripts

### DIFF
--- a/ashsthk_main.sh
+++ b/ashsthk_main.sh
@@ -1,4 +1,4 @@
-#/bin/bash
+#!/bin/bash
 #$ -S /bin/bash
 #set -e
 

--- a/docker_script/ashsthk_docker.sh
+++ b/docker_script/ashsthk_docker.sh
@@ -1,4 +1,4 @@
-#/bin/bash
+#!/bin/bash
 #$ -S /bin/bash
 set -e
 

--- a/docker_script/extract_label_thickness.sh
+++ b/docker_script/extract_label_thickness.sh
@@ -1,4 +1,4 @@
-#/bin/bash
+#!/bin/bash
 #$ -S /bin/bash
 set -e
 


### PR DESCRIPTION
The first line is currently `#/bin/bash`, instead of `#!/bin/bash`, which is why I think all the scripts are not directly executable (one has to run `bash <script>`).